### PR TITLE
Allow routes other than /blog (2-0-stable)

### DIFF
--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,0 +1,3 @@
+Spree::AppConfiguration.class_eval do
+  preference :blog_alias, :string, default: 'blog'
+end

--- a/app/views/spree/blog_entries/_news_archive.html.erb
+++ b/app/views/spree/blog_entries/_news_archive.html.erb
@@ -3,14 +3,14 @@
   <% d = DateTime.parse("1/#{year}") %>
 
   <li> <span></span>
-    <%= link_to(year, news_archive_path(:year => d.year)) %>
+    <%= link_to(year, blog_archive_path(:year => d.year)) %>
 
     <ul class="months">
     <% months_with_entries.each do |month, entries| %>
       <% d = DateTime.parse("#{year}, #{month}") %>
 
       <li> <span></span>
-        <%= link_to I18n.l(d, :format => "%B"), news_archive_path(:year => d.year, :month => d.month) %>
+        <%= link_to I18n.l(d, :format => "%B"), blog_archive_path(:year => d.year, :month => d.month) %>
 
         <ul class="posts">
           <% entries.each do |entry| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Spree::Core::Engine.routes.draw do
     match '/category/:category', :to => 'blog_entries#category', :as => :category
     match '/author/:author', :to => 'blog_entries#author', :as => :author
     match '/:year/:month/:day/:slug', :to => 'blog_entries#show', :as => :entry_permalink
-    match '/:year(/:month)(/:day)', :to => 'blog_entries#archive', :as => :archive,
+    match 'archive/:year(/:month)(/:day)', :to => 'blog_entries#archive', :as => :archive,
           :constraints => {:year => /(19|20)\d{2}/, :month => /[01]?\d/, :day => /[0-3]?\d/}
     match '/feed', :to => 'blog_entries#feed', :as => :feed, :format => :rss
     match '/', :to => 'blog_entries#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,16 @@ Spree::Core::Engine.routes.draw do
     resources :blog_entries
   end
   
-  resources :blog_entries
+  resources :blog_entries, path: Spree::Config['blog_alias']
 
-  match '/blog/tag/:tag', :to => 'blog_entries#tag', :as => :blog_tag
-  match '/blog/category/:category', :to => 'blog_entries#category', :as => :blog_category
-  match '/blog/author/:author', :to => 'blog_entries#author', :as => :blog_author
-  match '/blog/:year/:month/:day/:slug', :to => 'blog_entries#show', :as => :blog_entry_permalink
-  match '/blog/:year(/:month)(/:day)', :to => 'blog_entries#archive', :as => :news_archive,
-    :constraints => {:year => /(19|20)\d{2}/, :month => /[01]?\d/, :day => /[0-3]?\d/}
-  match '/blog/feed', :to => 'blog_entries#feed', :as => :blog_feed, :format => :rss
-  match '/blog', :to => 'blog_entries#index', :as => :blog
+  scope Spree::Config['blog_alias'], as: 'blog' do
+    match '/tag/:tag', :to => 'blog_entries#tag', :as => :tag
+    match '/category/:category', :to => 'blog_entries#category', :as => :category
+    match '/author/:author', :to => 'blog_entries#author', :as => :author
+    match '/:year/:month/:day/:slug', :to => 'blog_entries#show', :as => :entry_permalink
+    match '/:year(/:month)(/:day)', :to => 'blog_entries#archive', :as => :archive,
+          :constraints => {:year => /(19|20)\d{2}/, :month => /[01]?\d/, :day => /[0-3]?\d/}
+    match '/feed', :to => 'blog_entries#feed', :as => :feed, :format => :rss
+    match '/', :to => 'blog_entries#index'
+  end
 end


### PR DESCRIPTION
Hello!
This gem is nice and I used it on one of my projects. I had to change URLs for routes from 'blog' to 'news'. I want to share my implementation as I saw similar task in todo list.
I've added a new preference to Spree::Config. It's called 'blog_alias'.  In case of running Spree::Config[:blog_alias] = 'news', routes table will be as follows:

```
           blog_entries   GET    /news(.:format)                                     spree/blog_entries#index
                          POST   /news(.:format)                                     spree/blog_entries#create
         new_blog_entry   GET    /news/new(.:format)                                 spree/blog_entries#new
        edit_blog_entry   GET    /news/:id/edit(.:format)                            spree/blog_entries#edit
             blog_entry   GET    /news/:id(.:format)                                 spree/blog_entries#show
                          PUT    /news/:id(.:format)                                 spree/blog_entries#update
                          DELETE /news/:id(.:format)                                 spree/blog_entries#destroy
               blog_tag          /news/tag/:tag(.:format)                            spree/blog_entries#tag
          blog_category          /news/category/:category(.:format)                  spree/blog_entries#category
            blog_author          /news/author/:author(.:format)                      spree/blog_entries#author
   blog_entry_permalink          /news/:year/:month/:day/:slug(.:format)             spree/blog_entries#show
           blog_archive          /news/archive/:year(/:month)(/:day)(.:format)       spree/blog_entries#archive {:year=>/(19|20)\d{2}/, :month=>/[01]?\d/, :day=>/[0-3]?\d/}
              blog_feed          /news/feed(.:format)                                spree/blog_entries#feed {:format=>:rss}
                   blog          /news(.:format)                                     spree/blog_entries#index
```

In such a way helpers will always be unchanged and have prefix 'blog', and URl can be changed.
8 tests are failed now. I can fix these tests next time :)
